### PR TITLE
feat(bio-editor): add real-time theme preview functionality

### DIFF
--- a/src/components/ui/BioEditorUI.ts
+++ b/src/components/ui/BioEditorUI.ts
@@ -532,6 +532,9 @@ function renderBioEditorScripts(shortDomain: string): string {
         document.getElementById('bioDescription').value = bioPage.description || '';
         document.getElementById('bioTheme').value = bioPage.theme || 'default';
         
+        // Apply theme to preview
+        applyThemeToPreview(bioPage.theme || 'default');
+        
         // Update preview
         updatePreview();
         
@@ -722,6 +725,89 @@ function renderBioEditorScripts(shortDomain: string): string {
         return icons[platform.toLowerCase()] || '🔗';
     }
 
+    // Apply theme to preview
+    function applyThemeToPreview(themeName) {
+        const themes = {
+            default: {
+                background: 'linear-gradient(to bottom, #e2d9c2 0%, #65635a 100%)',
+                textPrimary: '#ffffff',
+                textSecondary: 'rgba(255, 255, 255, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#333333',
+            },
+            dark: {
+                background: 'linear-gradient(to bottom, #2d2c2a 0%, #1a1a1a 100%)',
+                textPrimary: '#ffffff',
+                textSecondary: 'rgba(255, 255, 255, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#333333',
+            },
+            ocean: {
+                background: 'linear-gradient(to bottom, #667eea 0%, #764ba2 100%)',
+                textPrimary: '#ffffff',
+                textSecondary: 'rgba(255, 255, 255, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#1a202c',
+            },
+            sunset: {
+                background: 'linear-gradient(to bottom, #f093fb 0%, #f5576c 100%)',
+                textPrimary: '#ffffff',
+                textSecondary: 'rgba(255, 255, 255, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#2d3748',
+            },
+            forest: {
+                background: 'linear-gradient(to bottom, #56ab2f 0%, #a8e063 100%)',
+                textPrimary: '#ffffff',
+                textSecondary: 'rgba(255, 255, 255, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#1a202c',
+            },
+            midnight: {
+                background: 'linear-gradient(to bottom, #232526 0%, #414345 100%)',
+                textPrimary: '#eaeaea',
+                textSecondary: 'rgba(234, 234, 234, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#333333',
+            },
+            minimal: {
+                background: '#f8f9fa',
+                textPrimary: '#212529',
+                textSecondary: 'rgba(33, 37, 41, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#212529',
+            },
+            candy: {
+                background: 'linear-gradient(to bottom, #ffecd2 0%, #fcb69f 100%)',
+                textPrimary: '#5a3e36',
+                textSecondary: 'rgba(90, 62, 54, 0.9)',
+                linkBg: 'rgba(255, 255, 255, 0.95)',
+                linkText: '#5a3e36',
+            },
+        };
+
+        const theme = themes[themeName] || themes.default;
+        const previewContent = document.getElementById('preview-content');
+        const previewTitle = document.getElementById('preview-title');
+        const previewDescription = document.getElementById('preview-description');
+        
+        if (previewContent) {
+            previewContent.style.background = theme.background;
+        }
+        if (previewTitle) {
+            previewTitle.style.color = theme.textPrimary;
+        }
+        if (previewDescription) {
+            previewDescription.style.color = theme.textSecondary;
+        }
+        
+        // Update link colors
+        document.querySelectorAll('.preview-link').forEach(link => {
+            link.style.background = theme.linkBg;
+            link.querySelector('.font-semibold').style.color = theme.linkText;
+        });
+    }
+
     // OG Image preview
     document.getElementById('ogImage').addEventListener('change', function(e) {
         const file = e.target.files[0];
@@ -891,6 +977,12 @@ function renderBioEditorScripts(shortDomain: string): string {
             submitButton.textContent = originalButtonText;
             submitButton.disabled = false;
         }
+    });
+
+    // Theme change listener to update preview
+    document.getElementById('bioTheme').addEventListener('change', function() {
+        const themeName = this.value || 'default';
+        applyThemeToPreview(themeName);
     });
 
     // Event listeners

--- a/src/config/bioThemes.client.ts
+++ b/src/config/bioThemes.client.ts
@@ -1,0 +1,102 @@
+/**
+ * Client-side Bio Page Theme Configuration
+ * This is a simplified version for use in the browser preview
+ */
+
+export interface BioTheme {
+	name: string;
+	displayName: string;
+	background: string;
+	containerBg: string;
+	textPrimary: string;
+	textSecondary: string;
+	linkCardBg: string;
+	linkIconBg: string;
+}
+
+export const BIO_THEMES_CLIENT: Record<string, BioTheme> = {
+	default: {
+		name: 'default',
+		displayName: 'Classic Beige',
+		background: 'linear-gradient(to bottom, #e2d9c2 0%, #65635a 100%)',
+		containerBg: '#ffffff',
+		textPrimary: '#333333',
+		textSecondary: '#666666',
+		linkCardBg: '#f5f5f5',
+		linkIconBg: '#ffffff',
+	},
+	dark: {
+		name: 'dark',
+		displayName: 'Dark Mode',
+		background: 'linear-gradient(to bottom, #2d2c2a 0%, #1a1a1a 100%)',
+		containerBg: '#222222',
+		textPrimary: '#ffffff',
+		textSecondary: '#aaaaaa',
+		linkCardBg: '#333333',
+		linkIconBg: '#444444',
+	},
+	ocean: {
+		name: 'ocean',
+		displayName: 'Ocean Blue',
+		background: 'linear-gradient(to bottom, #667eea 0%, #764ba2 100%)',
+		containerBg: '#ffffff',
+		textPrimary: '#1a202c',
+		textSecondary: '#4a5568',
+		linkCardBg: '#f7fafc',
+		linkIconBg: '#edf2f7',
+	},
+	sunset: {
+		name: 'sunset',
+		displayName: 'Sunset Orange',
+		background: 'linear-gradient(to bottom, #f093fb 0%, #f5576c 100%)',
+		containerBg: '#ffffff',
+		textPrimary: '#2d3748',
+		textSecondary: '#4a5568',
+		linkCardBg: '#fff5f7',
+		linkIconBg: '#fed7e2',
+	},
+	forest: {
+		name: 'forest',
+		displayName: 'Forest Green',
+		background: 'linear-gradient(to bottom, #56ab2f 0%, #a8e063 100%)',
+		containerBg: '#ffffff',
+		textPrimary: '#1a202c',
+		textSecondary: '#2d3748',
+		linkCardBg: '#f0fff4',
+		linkIconBg: '#c6f6d5',
+	},
+	midnight: {
+		name: 'midnight',
+		displayName: 'Midnight Purple',
+		background: 'linear-gradient(to bottom, #232526 0%, #414345 100%)',
+		containerBg: '#1a1a2e',
+		textPrimary: '#eaeaea',
+		textSecondary: '#b8b8b8',
+		linkCardBg: '#16213e',
+		linkIconBg: '#0f3460',
+	},
+	minimal: {
+		name: 'minimal',
+		displayName: 'Minimal White',
+		background: '#f8f9fa',
+		containerBg: '#ffffff',
+		textPrimary: '#212529',
+		textSecondary: '#6c757d',
+		linkCardBg: '#f8f9fa',
+		linkIconBg: '#e9ecef',
+	},
+	candy: {
+		name: 'candy',
+		displayName: 'Candy Pink',
+		background: 'linear-gradient(to bottom, #ffecd2 0%, #fcb69f 100%)',
+		containerBg: '#ffffff',
+		textPrimary: '#5a3e36',
+		textSecondary: '#8b6f66',
+		linkCardBg: '#fff5f0',
+		linkIconBg: '#ffe4d6',
+	},
+};
+
+export function getThemeClient(themeName: string): BioTheme {
+	return BIO_THEMES_CLIENT[themeName] || BIO_THEMES_CLIENT.default;
+}

--- a/src/routes/bio/handlers.ts
+++ b/src/routes/bio/handlers.ts
@@ -127,6 +127,7 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 			shortcode: string;
 			title: string;
 			description?: string;
+			theme?: string;
 			links: Array<{
 				title: string;
 				url: string;
@@ -141,7 +142,7 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 			ogImageUrl?: string;
 		};
 
-		let { shortcode, title, description, links, socialMedia, metaTitle, metaDescription, metaTags, ogImageUrl } = body;
+		let { shortcode, title, description, theme, links, socialMedia, metaTitle, metaDescription, metaTags, ogImageUrl } = body;
 
 		if (!shortcode || !title) {
 			return new Response(JSON.stringify({ success: false, message: 'Shortcode and title are required' }), {
@@ -182,7 +183,7 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 				title, 
 				description, 
 				null, // profile picture URL
-				'default', // theme
+				theme || 'default', // theme
 				links, // bio links array
 				socialMediaArray, // social media links array
 				metaTitle, // meta title


### PR DESCRIPTION
Add live theme preview updates in the bio editor to provide immediate visual feedback when users select different themes. The preview now dynamically applies theme colors and styles without requiring a save action.

Changes:
- Add `applyThemeToPreview()` function with 8 theme definitions (default, dark, ocean, sunset, forest, midnight, minimal, candy)
- Apply theme to preview on initial bio page load
- Add event listener to theme selector for real-time preview updates
- Update preview background, text colors, and link styles based on selected theme