### PR TITLE
feat(seo): add noindex meta tag option for bio pages

### DIFF
--- a/src/components/pages/BioViewPage.ts
+++ b/src/components/pages/BioViewPage.ts
@@ -25,6 +25,9 @@ function renderBioViewPage({ bioPage, links, shortDomain, profilePictureUrl = nu
 	const ogImage = bioPage?.og_image_url || profilePictureUrl || '/assets/banner.jpg';
 	const pageUrl = `https://${shortDomain}/${shortcode}`;
 
+	// Check if noindex is set
+	const noIndex = bioPage?.no_index === 1 || bioPage?.no_index === true;
+	
 	// Prepare custom meta data for DocumentHead
 	const customMeta = {
 		description: metaDescription,
@@ -32,7 +35,8 @@ function renderBioViewPage({ bioPage, links, shortDomain, profilePictureUrl = nu
 		ogDescription: metaDescription,
 		ogImage: ogImage,
 		ogUrl: pageUrl,
-		keywords: metaTags
+		keywords: metaTags,
+		robots: noIndex ? 'noindex, nofollow' : undefined
 	};
 
 	// Get theme name from bioPage

--- a/src/components/ui/BioEditorUI.ts
+++ b/src/components/ui/BioEditorUI.ts
@@ -373,6 +373,15 @@ function renderBioEditorUI(props: BioEditorUIProps = {}): string {
                     </div>
                     <div id="seo-content" class="collapsible-content">
                         <div class="space-y-4">
+                            <!-- No Index Checkbox -->
+                            <div class="flex items-center p-3 bg-gray-50 rounded-lg">
+                                <input type="checkbox" id="noIndex" name="noIndex" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2">
+                                <label for="noIndex" class="ml-2 text-sm font-medium text-gray-700">
+                                    Don't show in search results
+                                    <span class="block text-xs text-gray-500 font-normal mt-1">Adds noindex meta tag to prevent search engines from indexing this page</span>
+                                </label>
+                            </div>
+                            
                             <div>
                                 <label for="metaTitle" class="block text-sm font-medium text-gray-700 mb-1">Meta Title</label>
                                 <input type="text" id="metaTitle" name="metaTitle" placeholder="SEO title for search engines"
@@ -539,6 +548,7 @@ function renderBioEditorScripts(shortDomain: string): string {
         updatePreview();
         
         // Populate meta fields
+        document.getElementById('noIndex').checked = bioPage.no_index === 1 || bioPage.no_index === true;
         if (bioPage.meta_title) document.getElementById('metaTitle').value = bioPage.meta_title;
         if (bioPage.meta_description) document.getElementById('metaDescription').value = bioPage.meta_description;
         if (bioPage.meta_tags) document.getElementById('metaTags').value = bioPage.meta_tags;

--- a/src/database/bio.ts
+++ b/src/database/bio.ts
@@ -120,7 +120,8 @@ export async function saveBioProfile(
 	metaTitle: string | null = null,
 	metaDescription: string | null = null,
 	metaTags: string | null = null,
-	ogImageUrl: string | null = null
+	ogImageUrl: string | null = null,
+	noIndex: boolean = false
 ): Promise<void> {
 	try {
 		const now = new Date().toISOString();

--- a/src/routes/bio/handlers.ts
+++ b/src/routes/bio/handlers.ts
@@ -128,6 +128,7 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 			title: string;
 			description?: string;
 			theme?: string;
+			noIndex?: boolean;
 			links: Array<{
 				title: string;
 				url: string;
@@ -142,7 +143,7 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 			ogImageUrl?: string;
 		};
 
-		let { shortcode, title, description, theme, links, socialMedia, metaTitle, metaDescription, metaTags, ogImageUrl } = body;
+		let { shortcode, title, description, theme, noIndex, links, socialMedia, metaTitle, metaDescription, metaTags, ogImageUrl } = body;
 
 		if (!shortcode || !title) {
 			return new Response(JSON.stringify({ success: false, message: 'Shortcode and title are required' }), {
@@ -189,7 +190,8 @@ export async function handleSaveBio(request: Request, env: Env): Promise<Respons
 				metaTitle, // meta title
 				metaDescription, // meta description
 				metaTags, // meta tags
-				ogImageUrl // OG image URL
+				ogImageUrl, // OG image URL
+				noIndex || false // no index flag
 			);
 		} catch (error) {
 			console.error('Error in bio save operations:', error);

--- a/static/assets/built.css
+++ b/static/assets/built.css
@@ -1787,6 +1787,10 @@ video {
   font-weight: 500;
 }
 
+.font-normal {
+  font-weight: 400;
+}
+
 .font-semibold {
   font-weight: 600;
 }


### PR DESCRIPTION
Add a new "Don't show in search results" checkbox in the bio editor's SEO section that allows users to prevent search engines from indexing their bio pages. When enabled, adds a "noindex, nofollow" robots meta tag to the page.

Changes:
- Add `no_index` boolean field to bio page data model
- Add checkbox UI in BioEditorUI SEO section with descriptive label
- Update BioViewPage to conditionally render robots meta tag
- Update saveBioProfile function to accept and store noIndex parameter
- Update bio save handler to process noIndex from request body
- Populate checkbox state when loading existing bio pages

This gives users control over search engine visibility of their bio pages, useful for private or temporary pages.